### PR TITLE
以可选配置的形式修复了掉落物合并死循环的问题

### DIFF
--- a/src/main/java/net/carbonmc/graphene/config/CoolConfig.java
+++ b/src/main/java/net/carbonmc/graphene/config/CoolConfig.java
@@ -68,6 +68,7 @@ public class CoolConfig {
     public static ForgeConfigSpec.BooleanValue OpenIO;
     public static ForgeConfigSpec.IntValue maxStackSize;
     public static ForgeConfigSpec.DoubleValue mergeDistance;
+    public static ForgeConfigSpec.BooleanValue lockMaxedStacks;
     public static ForgeConfigSpec.IntValue listMode;
     public static ForgeConfigSpec.ConfigValue<List<? extends String>> itemList;
     public static ForgeConfigSpec.BooleanValue showStackCount;
@@ -349,6 +350,10 @@ public class CoolConfig {
                         "在合并后的物品上显示堆叠数量",
                         "Show stack count on merged items")
                 .define("showStackCount", true);
+        lockMaxedStacks = BUILDER.comment(
+                        "当物品堆叠达到最大时锁定，不再参与合并",
+                        "Lock stacks that have reached the maximum size to prevent further merging")
+                .define("lockMaxedStacks", true);
         BUILDER.pop(); // 堆叠合并
 
         BUILDER.push("自定义堆叠 | Custom Stack Size");

--- a/src/main/java/net/carbonmc/graphene/mixin/stack/ItemEntityMixin.java
+++ b/src/main/java/net/carbonmc/graphene/mixin/stack/ItemEntityMixin.java
@@ -122,11 +122,14 @@ public abstract class ItemEntityMixin {
 
     @Unique
     private boolean isValidMergeTarget(ItemEntity self, ItemEntity other, int listMode, List<? extends String> itemList) {
+        int configMax = CoolConfig.maxStackSize.get() > 0 ? CoolConfig.maxStackSize.get() : Integer.MAX_VALUE;
+        boolean lockMaxedStacks = CoolConfig.lockMaxedStacks.get();
 
         return self != other &&
                 !other.isRemoved() &&
                 isSameItem(self.getItem(), other.getItem()) &&
-                isMergeAllowed(other.getItem(), listMode, itemList);
+                isMergeAllowed(other.getItem(), listMode, itemList) &&
+                (! lockMaxedStacks || other.getItem().getCount() < configMax);
     }
 
     @Unique


### PR DESCRIPTION
在CoolConfig.java中添加了新配置lockMaxedStacks
在ItemEntityMixin.java中修改了isValidMergeTarget()方法的逻辑，具体如下：
如果物品优化为开，且lockMaxedStacks也为开，那么isValidMergeTarget()方法在确定物品是否可以合并时将额外判断被合并方的数量是否已经抵达最大堆叠数量，如果是，则跳过，不会与其合并；如果不是，则合并。在此情况下，已经抵达最大堆叠数量的掉落物实体将不可被合并，也不可主动合并其他同类掉落物实体。以避免已经抵达最大数量的掉落物实体又与其他未抵达最大数量的掉落物实体相互合并导致死循环。（ 有点拗口( ）

相关验证：
1.修复后，掉落物实体的Age数据不再一直重置为-6000
2.原Jade可见的数量转移现象消失
3.相对修复前，鼓风机效率更加正常(但是仍然会随着maxStackSize配置值的变大导致处理极差变大(一次性处理量变大))

尽管该项修复为可选项，但一般不建议关闭（默认开启）

验证附件：

https://github.com/user-attachments/assets/5a75d2aa-bcd7-448d-9ae4-a2374aa179d7

Fixes #1 